### PR TITLE
Add AI inference platform example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,37 @@
-# bfx-wrk-base
+# AI Inference Platform Sample
 
-git clone git@github.com:bitfinexcom/REPO.git REPO
+This repository contains a minimal microservice-based inference platform that
+follows the paradigm of `base.js`. The platform exposes an RPC interface over a
+lightweight Hyperswarm RPC implementation and provides a small web interface for
+user management and metrics.
 
-git remote -v
+## Quickstart
 
-git remote add upstream git@github.com:bitfinexcom/PARENT.git
+1. Install dependencies (none are required besides Node.js).
+2. Start the worker:
+   ```bash
+   npm start
+   ```
+   The worker listens for RPC connections on port `9000` and HTTP on port `9001`.
 
-git remote -v
+3. Register a user:
+   ```bash
+   curl -X POST -d '{"username":"alice"}' http://localhost:9001/register
+   ```
+   Save the returned `apiKey` in `cli/config.json`.
 
-git push origin master
+4. Run the CLI:
+   ```bash
+   node cli/index.js "your prompt here"
+   ```
+
+5. Metrics are available on `http://localhost:9001/metrics`.
+
+## Tests
+
+Run unit tests with:
+```
+npm test
+```
+
+For detailed design notes see [docs/architecture.md](docs/architecture.md).

--- a/cli/config.json
+++ b/cli/config.json
@@ -1,0 +1,6 @@
+{
+  "host": "127.0.0.1",
+  "rpcPort": 9000,
+  "apiKey": "YOUR_API_KEY"
+}
+

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const { RPCClient } = require('../lib/hyperswarm-rpc')
+const fs = require('fs')
+const path = require('path')
+
+function loadConfig () {
+  const p = path.join(__dirname, 'config.json')
+  return JSON.parse(fs.readFileSync(p, 'utf8'))
+}
+
+function main () {
+  const prompt = process.argv.slice(2).join(' ')
+  if (!prompt) {
+    console.log('Usage: node cli/index.js <prompt>')
+    return
+  }
+  const conf = loadConfig()
+  const client = new RPCClient(conf.rpcPort || 9000, conf.host || '127.0.0.1')
+  client.connect(() => {
+    client.request('inference', { key: conf.apiKey, prompt }, (err, res) => {
+      if (err) console.error('Error:', err)
+      else console.log(res)
+      client.close()
+    })
+  })
+}
+
+main()

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,30 @@
+# API Documentation
+
+## RPC API
+
+### `inference`
+
+Request body:
+```
+{ "key": "<apiKey>", "prompt": "text" }
+```
+
+Response body:
+```
+{ "reply": "model reply" }
+```
+
+Errors are returned as RPC errors in the response.
+
+## HTTP API
+
+### `POST /register`
+Create a new user.
+Request JSON: `{ "username": "alice" }`
+Response JSON: `{ "apiKey": "..." }`
+
+### `GET /usage?key=<apiKey>`
+Returns current usage counter.
+
+### `GET /metrics`
+Exposes Prometheus metrics.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,37 @@
+# AI Inference Platform Design
+
+This document describes the architecture of the AI inference platform. The goal is
+to expose inference capabilities over Hyperswarm RPC and provide a simple web
+interface for account management and metrics.
+
+## Components
+
+- **Inference Worker** – microservice handling inference requests via RPC. It
+  extends `base.js` and exposes an RPC method `inference`. The worker also runs a
+  small HTTP server used for user registration, usage checks and Prometheus
+  metrics.
+- **CLI** – command line tool that sends RPC requests to the inference worker.
+- **Hyperswarm RPC layer** – lightweight RPC implementation used by the worker
+  and CLI. In production it can be replaced by a real Hyperswarm RPC library.
+
+```
+flowchart TD
+  subgraph Client
+    CLI
+  end
+  subgraph Services
+    InferenceWorker
+  end
+  CLI -- RPC --> InferenceWorker
+  WebBrowser -- HTTP --> InferenceWorker
+```
+
+## User Flow
+
+1. A user registers via `POST /register` on the worker HTTP interface and
+   receives an API key.
+2. The API key is stored in the CLI configuration.
+3. The CLI issues RPC calls with the API key and a prompt.
+4. The worker verifies the key, checks the rate limit, performs the inference
+   (here the implementation simply echoes the prompt) and returns the result.
+5. Metrics are available on `/metrics` for Prometheus scraping.

--- a/lib/hyperswarm-rpc.js
+++ b/lib/hyperswarm-rpc.js
@@ -1,0 +1,98 @@
+'use strict'
+
+const net = require('net')
+
+class RPCServer {
+  constructor (port = 9000) {
+    this.port = port
+    this.methods = {}
+  }
+
+  register (name, fn) {
+    this.methods[name] = fn
+  }
+
+  listen (cb) {
+    this.server = net.createServer(socket => {
+      let buf = ''
+      socket.on('data', chunk => {
+        buf += chunk.toString()
+        let i
+        while ((i = buf.indexOf('\n')) >= 0) {
+          const line = buf.slice(0, i)
+          buf = buf.slice(i + 1)
+          if (!line.trim()) continue
+          let msg
+          try {
+            msg = JSON.parse(line)
+          } catch (e) {
+            continue
+          }
+          const handler = this.methods[msg.method]
+          if (!handler) {
+            socket.write(JSON.stringify({ id: msg.id, error: 'Method not found' }) + '\n')
+            continue
+          }
+          Promise.resolve(handler(msg.params))
+            .then(res => {
+              socket.write(JSON.stringify({ id: msg.id, result: res }) + '\n')
+            })
+            .catch(err => {
+              socket.write(JSON.stringify({ id: msg.id, error: err.message }) + '\n')
+            })
+        }
+      })
+    })
+    this.server.listen(this.port, cb)
+  }
+
+  close (cb) {
+    if (this.server) this.server.close(cb)
+  }
+}
+
+class RPCClient {
+  constructor (port = 9000, host = '127.0.0.1') {
+    this.port = port
+    this.host = host
+    this.id = 0
+    this.pending = {}
+  }
+
+  connect (cb) {
+    this.socket = net.connect(this.port, this.host, cb)
+    let buf = ''
+    this.socket.on('data', chunk => {
+      buf += chunk.toString()
+      let i
+      while ((i = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, i)
+        buf = buf.slice(i + 1)
+        if (!line.trim()) continue
+        let msg
+        try {
+          msg = JSON.parse(line)
+        } catch (e) {
+          continue
+        }
+        const cb = this.pending[msg.id]
+        if (cb) {
+          delete this.pending[msg.id]
+          cb(msg.error, msg.result)
+        }
+      }
+    })
+  }
+
+  request (method, params, cb) {
+    const id = ++this.id
+    this.pending[id] = cb
+    this.socket.write(JSON.stringify({ id, method, params }) + '\n')
+  }
+
+  close () {
+    if (this.socket) this.socket.end()
+  }
+}
+
+module.exports = { RPCServer, RPCClient }

--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
       "name": "prdn",
       "email": "paolo@bitfinex.com"
     }
-  ]
+  ],
+  "scripts": {
+    "start": "node services/run.js",
+    "test": "node tests/test.js"
+  }
 }

--- a/services/inference-worker.js
+++ b/services/inference-worker.js
@@ -1,0 +1,97 @@
+'use strict'
+
+const Base = require('../base')
+const { RPCServer } = require('../lib/hyperswarm-rpc')
+const crypto = require('crypto')
+const http = require('http')
+
+class InferenceWorker extends Base {
+  constructor (conf, ctx) {
+    super(conf, ctx)
+    this.users = {}
+    this.rateLimit = conf.rateLimit || 10
+    this.metrics = { requests: 0, fails: 0 }
+  }
+
+  _start (cb) {
+    this.rpc = new RPCServer(this.conf.rpcPort)
+    this.rpc.register('inference', async (params) => this.handleInference(params))
+    this.rpc.listen(() => console.log(`RPC listening on ${this.conf.rpcPort}`))
+
+    this.httpServer = http.createServer((req, res) => this.handleHttp(req, res))
+    this.httpServer.listen(this.conf.httpPort, () => console.log(`HTTP listening on ${this.conf.httpPort}`))
+    cb()
+  }
+
+  handleHttp (req, res) {
+    if (req.method === 'POST' && req.url === '/register') {
+      let body = ''
+      req.on('data', chunk => { body += chunk.toString() })
+      req.on('end', () => {
+        const { username } = JSON.parse(body || '{}')
+        const key = crypto.randomBytes(8).toString('hex')
+        this.users[key] = { username, usage: 0, last: Date.now(), count: 0 }
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ apiKey: key }))
+      })
+      return
+    }
+
+    if (req.method === 'GET' && req.url.startsWith('/usage')) {
+      const url = new URL(req.url, `http://${req.headers.host}`)
+      const key = url.searchParams.get('key')
+      if (!this.users[key]) {
+        res.writeHead(404)
+        res.end()
+        return
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ usage: this.users[key].usage }))
+      return
+    }
+
+    if (req.method === 'GET' && req.url === '/metrics') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end(`requests ${this.metrics.requests}\nfailures ${this.metrics.fails}\n`)
+      return
+    }
+
+    res.writeHead(404)
+    res.end()
+  }
+
+  async handleInference (params = {}) {
+    const { key, prompt } = params
+    if (!this.users[key]) {
+      this.metrics.fails++
+      throw new Error('invalid api key')
+    }
+    if (!this.checkRateLimit(key)) {
+      this.metrics.fails++
+      throw new Error('rate limit exceeded')
+    }
+    this.metrics.requests++
+    this.users[key].usage++
+    const reply = `Echo: ${prompt}`
+    return { reply }
+  }
+
+  checkRateLimit (key) {
+    const usr = this.users[key]
+    const now = Date.now()
+    if (now - usr.last > 60000) {
+      usr.last = now
+      usr.count = 0
+    }
+    usr.count = (usr.count || 0) + 1
+    return usr.count <= this.rateLimit
+  }
+
+  _stop (cb) {
+    this.rpc.close(() => {
+      this.httpServer.close(cb)
+    })
+  }
+}
+
+module.exports = InferenceWorker

--- a/services/run.js
+++ b/services/run.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const InferenceWorker = require('./inference-worker')
+
+const worker = new InferenceWorker({
+  rpcPort: 9000,
+  httpPort: 9001,
+  rateLimit: 5
+}, { env: 'dev', root: __dirname, wtype: 'inference' })
+
+worker.init()
+worker.start(() => console.log('Worker started'))

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,32 @@
+'use strict'
+const assert = require('assert')
+const http = require('http')
+const InferenceWorker = require('../services/inference-worker')
+const { RPCClient } = require('../lib/hyperswarm-rpc')
+
+const worker = new InferenceWorker({ rpcPort: 9100, httpPort: 9101, rateLimit: 2 }, { env: 'test', root: __dirname, wtype: 'inference' })
+worker.init()
+
+worker.start(() => {
+  const data = JSON.stringify({ username: 'tester' })
+  const req = http.request({ hostname: '127.0.0.1', port: 9101, path: '/register', method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) } }, res => {
+    let body = ''
+    res.on('data', d => { body += d })
+    res.on('end', () => {
+      const { apiKey } = JSON.parse(body)
+      const client = new RPCClient(9100, '127.0.0.1')
+      client.connect(() => {
+        client.request('inference', { key: apiKey, prompt: 'hi' }, (err, result) => {
+          assert.ifError(err)
+          assert.strictEqual(result.reply, 'Echo: hi')
+          client.close()
+          worker.stop(() => {
+            console.log('tests passed')
+          })
+        })
+      })
+    })
+  })
+  req.write(data)
+  req.end()
+})


### PR DESCRIPTION
## Summary
- add simple RPC implementation to mimic Hyperswarm RPC
- implement `InferenceWorker` microservice with rate limiting and metrics
- CLI to perform inference requests via RPC
- docs for architecture and API
- tests for worker and CLI interaction

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_683ccd4186808321ae471302e779ef5f